### PR TITLE
Fix typo

### DIFF
--- a/threatconnect/Resources/Owners.py
+++ b/threatconnect/Resources/Owners.py
@@ -35,7 +35,7 @@ class Owners(Resource):
         request_object.set_resource_pagination(resource_properties['base']['pagination'])
         request_object.set_resource_type(self._resource_type)
         return request_object
-s
+
     def get_owner_by_id(self, data_int):
         """ return owner by id """
         if isinstance(data_int, int):


### PR DESCRIPTION
Fix a typo from 29716d6909945ef0203463ec2a86ec3d3a19cf6d.

I couldn't figure out how to run the tests (or find documentation on it), but I was able to import the file. But please let me know if there's something I should run.

Thanks!