### PR TITLE
Add Console Script for App Testing with an Entry Point

### DIFF
--- a/bin/stanchion.py
+++ b/bin/stanchion.py
@@ -29,8 +29,8 @@ def main():
     log_path = working_dir
     arguments = ['--tc_log_path', log_path]
 
-    for argument_pair in config.defaults():
-        arguments.extend(list(argument_pair))
+    for argument, datum in config.defaults().items():
+        arguments.extend([argument, datum])
 
     command = ['python', args.target]
     command.extend(arguments)

--- a/bin/stanchion.py
+++ b/bin/stanchion.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""A command line tool for testing App Engine apps.
+
+It feeds the app command line arguments. This simulates the way that
+Apps are started in the TC Exchange runtime environment.
+"""
+
+import argparse
+import ConfigParser
+import os
+import subprocess
+
+
+def main():
+    """Main function for the tool."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('target', metavar='TARGET', help='Target python script to test')
+
+    args, unknown = parser.parse_known_args()
+
+    working_dir = os.getcwd()
+
+    config = ConfigParser.RawConfigParser()
+    config_file = os.path.join(working_dir, 'app.conf')
+    config.read(config_file)
+
+    log_path = working_dir
+    arguments = ['--tc_log_path', log_path]
+
+    for argument_pair in config.defaults():
+        arguments.extend(list(argument_pair))
+
+    command = ['python', args.target]
+    command.extend(arguments)
+
+    subprocess.call(command)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
     # test_suite = '',
     url='https://github.com/ThreatConnect-Inc/threatconnect-python',
     license='GPLv3',
-    install_requires=['requests', 'enum34', 'python-dateutil', 'psutil'],
+    install_requires=['requests', 'python-dateutil', 'psutil'],
+    extras_require={
+        ':python_version=="2.7"': ['enum34']
+    },
     # test_suite = '',
     use_2to3=True,
     # convert_2to3_doctests = [''],

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,9 @@ setup(
     # convert_2to3_doctests = [''],
     # use_2to3_fixers = [''],
     use_2to3_exclude_fixers=['lib2to3.fixes.fix_print'],
+    entry_points={
+        'console_scripts': [
+            'stanchion=bin.stanchion:main'
+        ],
+    },
 )


### PR DESCRIPTION
This will create a command line console script that takes a generic app.conf file of the following form for testing apps:

[DEFAULT]
--api_access_id = 1234123412341234
--api_secret_key = asdfasdfasdfasdfasdf

An arbitrary number of command line arguments will be read from the config file and fed to the Exchange app to simulate the runtime environment.