### PR TITLE
Changes to allow compile on Windows 7 Python 3.4.3, OS X(EC) Python 3.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,13 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='threatconnect',
-    version='2.03',
+    version='2.3',
     description='Python wrapper for ThreatConnect API',
     author='ThreatConnect',
     author_email='support@threatconnect.com',
     # package_dir = {'': 'src'},
-    packages=[
-        'threatconnect',
-        'threatconnect/Config',
-        'threatconnect/Resources'],
-    py_modules=[
-        'threatconnect',
-        'threatconnect/Config',
-        'threatconnect/Resources'],
+    packages=find_packages(),
     # test_suite = '',
     url='https://github.com/ThreatConnect-Inc/threatconnect-python',
     license='GPLv3',

--- a/threatconnect/AttributeObject.py
+++ b/threatconnect/AttributeObject.py
@@ -1,10 +1,10 @@
 """ standard """
-from threatconnect import ApiProperties
-from threatconnect.RequestObject import RequestObject
-from threatconnect.SecurityLabelObject import parse_security_label, SecurityLabelObject
+import ApiProperties
+from RequestObject import RequestObject
+from SecurityLabelObject import parse_security_label, SecurityLabelObject
 
 """ custom """
-from threatconnect.ErrorCodes import ErrorCodes
+from ErrorCodes import ErrorCodes
 
 
 def parse_attribute(attribute_dict, container):

--- a/threatconnect/BatchJobFilterMethods.py
+++ b/threatconnect/BatchJobFilterMethods.py
@@ -1,5 +1,5 @@
-from threatconnect.ErrorCodes import ErrorCodes
-from threatconnect.RequestObject import RequestObject
+from ErrorCodes import ErrorCodes
+from RequestObject import RequestObject
 
 
 def add_id(self, data_int):

--- a/threatconnect/BatchJobObject.py
+++ b/threatconnect/BatchJobObject.py
@@ -3,9 +3,9 @@ import json
 
 """ custom """
 
-from threatconnect import ApiProperties
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.RequestObject import RequestObject
+import ApiProperties
+from Config.ResourceType import ResourceType
+from RequestObject import RequestObject
 
 
 class BatchJobObject(object):

--- a/threatconnect/DnsResolutionObject.py
+++ b/threatconnect/DnsResolutionObject.py
@@ -1,5 +1,5 @@
 """ standard """
-from threatconnect.Config.ResourceType import ResourceType
+from Config.ResourceType import ResourceType
 
 
 def parse_dns_resolution(dr_dict):

--- a/threatconnect/FilterObject.py
+++ b/threatconnect/FilterObject.py
@@ -2,8 +2,8 @@
 import re
 
 """ custom """
-from threatconnect.Config.FilterOperator import FilterSetOperator
-from threatconnect.ErrorCodes import ErrorCodes
+from Config.FilterOperator import FilterSetOperator
+from ErrorCodes import ErrorCodes
 
 
 class FilterObject(object):

--- a/threatconnect/GroupFilterMethods.py
+++ b/threatconnect/GroupFilterMethods.py
@@ -6,12 +6,12 @@ import dateutil.parser
 
 """ custom """
 from Config.FilterOperator import FilterOperator
-from threatconnect import ApiProperties
-from threatconnect import SharedMethods
+import ApiProperties
+import SharedMethods
 
-from threatconnect.ErrorCodes import ErrorCodes
-from threatconnect.PostFilterObject import PostFilterObject
-from threatconnect.RequestObject import RequestObject
+from ErrorCodes import ErrorCodes
+from PostFilterObject import PostFilterObject
+from RequestObject import RequestObject
 
 
 def add_adversary_id(self, data_int):

--- a/threatconnect/GroupObject.py
+++ b/threatconnect/GroupObject.py
@@ -8,18 +8,18 @@ except ImportError:
     from io import StringIO
 
 """ custom """
-from threatconnect.AttributeObject import parse_attribute, AttributeObject
-import threatconnect.IndicatorObject
-from threatconnect.SecurityLabelObject import parse_security_label
-from threatconnect.TagObject import parse_tag
-from threatconnect.VictimObject import parse_victim
+from AttributeObject import parse_attribute, AttributeObject
+# import IndicatorObject  #Causes circular import
+from SecurityLabelObject import parse_security_label
+from TagObject import parse_tag
+# import VictimObject
 
-from threatconnect import ApiProperties
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.ErrorCodes import ErrorCodes
+import ApiProperties
+from Config.ResourceType import ResourceType
+from ErrorCodes import ErrorCodes
 
-from threatconnect.RequestObject import RequestObject
-from threatconnect.SharedMethods import get_resource_group_type
+from RequestObject import RequestObject
+from SharedMethods import get_resource_group_type
 
 
 def parse_group(group_dict, resource_type=ResourceType.GROUPS, resource_obj=None, api_filter=None, request_uri=None):
@@ -1164,7 +1164,9 @@ class GroupObjectAdvanced(GroupObject):
         ro.set_resource_type(self._resource_type)
 
         for item in self._tc.result_pagination(ro, 'indicator'):
-            yield threatconnect.IndicatorObject.parse_indicator(
+            import IndicatorObject  #Causes circular import
+
+            yield IndicatorObject.parse_indicator(
                 item, api_filter=ro.description, request_uri=ro.request_uri, indicators_regex=self._tc._indicators_regex)
 
     @property

--- a/threatconnect/IndicatorFilterMethods.py
+++ b/threatconnect/IndicatorFilterMethods.py
@@ -6,13 +6,13 @@ import dateutil.parser
 
 """ custom """
 from Config.FilterOperator import FilterOperator
-from threatconnect import ApiProperties
-from threatconnect import SharedMethods
+import ApiProperties
+import SharedMethods
 
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.ErrorCodes import ErrorCodes
-from threatconnect.PostFilterObject import PostFilterObject
-from threatconnect.RequestObject import RequestObject
+from Config.ResourceType import ResourceType
+from ErrorCodes import ErrorCodes
+from PostFilterObject import PostFilterObject
+from RequestObject import RequestObject
 
 
 def add_adversary_id(self, data_int):

--- a/threatconnect/IndicatorObject.py
+++ b/threatconnect/IndicatorObject.py
@@ -8,19 +8,20 @@ except ImportError:
     from io import StringIO
 
 """ custom """
-from threatconnect.AttributeObject import parse_attribute, AttributeObject
-from threatconnect.FileOccurrenceObject import parse_file_occurrence
-import threatconnect.GroupObject
-from threatconnect.SecurityLabelObject import parse_security_label
-from threatconnect.TagObject import parse_tag
-from threatconnect.VictimObject import parse_victim
+import VictimObject
+from AttributeObject import parse_attribute, AttributeObject
+from FileOccurrenceObject import parse_file_occurrence
+import GroupObject
+from SecurityLabelObject import parse_security_label
+from TagObject import parse_tag
 
-from threatconnect import ApiProperties
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.ErrorCodes import ErrorCodes
 
-from threatconnect.RequestObject import RequestObject
-from threatconnect.SharedMethods import get_resource_type, get_hash_type, get_resource_indicator_type
+import ApiProperties
+from Config.ResourceType import ResourceType
+from ErrorCodes import ErrorCodes
+
+from RequestObject import RequestObject
+from SharedMethods import get_resource_type, get_hash_type, get_resource_indicator_type
 
 
 def parse_indicator(indicator_dict, resource_obj=None, api_filter=None, request_uri=None, indicators_regex=None):
@@ -1310,7 +1311,7 @@ class IndicatorObjectAdvanced(IndicatorObject):
         ro.set_resource_type(self._resource_type)
 
         for item in self._tc.result_pagination(ro, 'group'):
-            yield threatconnect.GroupObject.parse_group(item, api_filter=ro.description, request_uri=ro.request_uri)
+            yield GroupObject.parse_group(item, api_filter=ro.description, request_uri=ro.request_uri)
 
     @property
     def indicator_associations(self):

--- a/threatconnect/OwnerFilterMethods.py
+++ b/threatconnect/OwnerFilterMethods.py
@@ -2,12 +2,12 @@
 
 """ custom """
 from Config.FilterOperator import FilterOperator
-from threatconnect import ApiProperties
-from threatconnect import SharedMethods
+import ApiProperties
+import SharedMethods
 
-from threatconnect.ErrorCodes import ErrorCodes
-from threatconnect.PostFilterObject import PostFilterObject
-from threatconnect.RequestObject import RequestObject
+from ErrorCodes import ErrorCodes
+from PostFilterObject import PostFilterObject
+from RequestObject import RequestObject
 
 
 def add_indicator(self, data):

--- a/threatconnect/OwnerObject.py
+++ b/threatconnect/OwnerObject.py
@@ -9,9 +9,9 @@ except ImportError:
 
 """ custom """
 
-from threatconnect import ApiProperties
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.ErrorCodes import ErrorCodes
+import ApiProperties
+from Config.ResourceType import ResourceType
+from ErrorCodes import ErrorCodes
 
 
 def parse_owner(owner_dict, resource_obj=None, api_filter=None, request_uri=None):

--- a/threatconnect/PostFilterObject.py
+++ b/threatconnect/PostFilterObject.py
@@ -1,7 +1,7 @@
 """ custom """
-from threatconnect import SharedMethods
-from threatconnect.Config.FilterOperator import FilterOperator
-from threatconnect.ErrorCodes import ErrorCodes
+import SharedMethods
+from Config.FilterOperator import FilterOperator
+from ErrorCodes import ErrorCodes
 
 
 class PostFilterObject(object):

--- a/threatconnect/ReportEntry.py
+++ b/threatconnect/ReportEntry.py
@@ -1,5 +1,5 @@
 """ custom """
-from threatconnect import SharedMethods
+import SharedMethods
 
 
 class ReportEntry(object):

--- a/threatconnect/RequestObject.py
+++ b/threatconnect/RequestObject.py
@@ -1,5 +1,5 @@
 
-from threatconnect import ErrorCodes
+import ErrorCodes
 
 
 class RequestObject(object):

--- a/threatconnect/Resource.py
+++ b/threatconnect/Resource.py
@@ -2,15 +2,15 @@
 import dateutil.parser
 import time
 import uuid
-from threatconnect.BatchJobObject import BatchJobObject
+from BatchJobObject import BatchJobObject
 
 """ custom """
-from threatconnect.GroupObject import GroupObject
-from threatconnect.VictimObject import VictimObject
+from GroupObject import GroupObject
+from VictimObject import VictimObject
 
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.Config.FilterOperator import FilterOperator
-from threatconnect.ErrorCodes import ErrorCodes
+from Config.ResourceType import ResourceType
+from Config.FilterOperator import FilterOperator
+from ErrorCodes import ErrorCodes
 
 
 class Resource(object):

--- a/threatconnect/SharedMethods.py
+++ b/threatconnect/SharedMethods.py
@@ -2,8 +2,8 @@
 import urllib
 
 """ custom """
-from threatconnect.Config.ResourceRegexes import md5_re, sha1_re, sha256_re
-from threatconnect.Config.ResourceType import ResourceType
+from Config.ResourceRegexes import md5_re, sha1_re, sha256_re
+from Config.ResourceType import ResourceType
 
 # group type to resource type mapping
 g_type_to_r_type = {

--- a/threatconnect/ThreatConnect.py
+++ b/threatconnect/ThreatConnect.py
@@ -9,7 +9,7 @@ import os
 import re
 import socket
 import time
-from threatconnect.DnsResolutionObject import parse_dns_resolution
+from DnsResolutionObject import parse_dns_resolution
 
 """ third-party """
 from requests import (exceptions, packages, Request, Session)
@@ -22,34 +22,34 @@ packages.urllib3.disable_warnings()
 # import psutil
 
 """ custom """
-from threatconnect.ErrorCodes import ErrorCodes
+from ErrorCodes import ErrorCodes
 
 # tc config modules
-from threatconnect.Config.FilterOperator import FilterSetOperator
-from threatconnect.Config.IndicatorType import IndicatorType
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.Config.ResourceRegexes import indicators_regex
+from Config.FilterOperator import FilterSetOperator
+from Config.IndicatorType import IndicatorType
+from Config.ResourceType import ResourceType
+from Config.ResourceRegexes import indicators_regex
 
-from threatconnect.IndicatorObject import parse_indicator
-from threatconnect.GroupObject import parse_group
-from threatconnect.OwnerObject import parse_owner
-from threatconnect.VictimObject import parse_victim
-from threatconnect.Resources.BatchJobs import BatchJobs, parse_batch_job
+from IndicatorObject import parse_indicator
+from GroupObject import parse_group
+from OwnerObject import parse_owner
+from VictimObject import parse_victim
+from Resources.BatchJobs import BatchJobs, parse_batch_job
 
-from threatconnect.ReportEntry import ReportEntry
-from threatconnect.Report import Report
-from threatconnect.Resources.Adversaries import Adversaries
-from threatconnect.Resources.Bulk import Bulk
-from threatconnect.Resources.BulkIndicators import BulkIndicators
-from threatconnect.Resources.Documents import Documents
-from threatconnect.Resources.Emails import Emails
-from threatconnect.Resources.Groups import Groups
-from threatconnect.Resources.Incidents import Incidents
-from threatconnect.Resources.Indicators import Indicators
-from threatconnect.Resources.Owners import Owners
-from threatconnect.Resources.Threats import Threats
-from threatconnect.Resources.Signatures import Signatures
-from threatconnect.Resources.Victims import Victims
+from ReportEntry import ReportEntry
+from Report import Report
+from Resources.Adversaries import Adversaries
+from Resources.Bulk import Bulk
+from Resources.BulkIndicators import BulkIndicators
+from Resources.Documents import Documents
+from Resources.Emails import Emails
+from Resources.Groups import Groups
+from Resources.Incidents import Incidents
+from Resources.Indicators import Indicators
+from Resources.Owners import Owners
+from Resources.Threats import Threats
+from Resources.Signatures import Signatures
+from Resources.Victims import Victims
 
 
 def create_tc_arg_parser():

--- a/threatconnect/VictimAssetObject.py
+++ b/threatconnect/VictimAssetObject.py
@@ -1,9 +1,9 @@
 """ standard """
 import json
-from threatconnect.ErrorCodes import ErrorCodes
+from ErrorCodes import ErrorCodes
 
 """ custom """
-from threatconnect.Config.ResourceType import ResourceType
+from Config.ResourceType import ResourceType
 # from threatconnect.ErrorCodes import ErrorCodes
 
 

--- a/threatconnect/VictimFilterMethods.py
+++ b/threatconnect/VictimFilterMethods.py
@@ -6,12 +6,12 @@ import dateutil.parser
 
 """ custom """
 from Config.FilterOperator import FilterOperator
-from threatconnect import ApiProperties
-from threatconnect import SharedMethods
+import ApiProperties
+import SharedMethods
 
-from threatconnect.ErrorCodes import ErrorCodes
-from threatconnect.PostFilterObject import PostFilterObject
-from threatconnect.RequestObject import RequestObject
+from ErrorCodes import ErrorCodes
+from PostFilterObject import PostFilterObject
+from RequestObject import RequestObject
 
 
 def add_adversary_id(self, data_int):

--- a/threatconnect/VictimObject.py
+++ b/threatconnect/VictimObject.py
@@ -8,14 +8,15 @@ except ImportError:
     from io import StringIO
 
 """ custom """
-import threatconnect.GroupObject
-import threatconnect.IndicatorObject
-from threatconnect.VictimAssetObject import parse_victim_asset
+# import IndicatorObject
+import GroupObject
 
-from threatconnect import ApiProperties
-from threatconnect.Config.ResourceType import ResourceType
-from threatconnect.ErrorCodes import ErrorCodes
-from threatconnect.RequestObject import RequestObject
+from VictimAssetObject import parse_victim_asset
+
+import ApiProperties
+from Config.ResourceType import ResourceType
+from ErrorCodes import ErrorCodes
+from RequestObject import RequestObject
 
 
 def parse_victim(victim_dict, resource_obj=None, api_filter=None, request_uri=None):

--- a/threatconnect/__init__.py
+++ b/threatconnect/__init__.py
@@ -4,16 +4,16 @@ __version__ = '2.0'
 __license__ = 'GPLv3'
 __url__ = 'https://github.com/ThreatConnect-Inc/threatconnect-python'
 
-from threatconnect.ThreatConnect import ThreatConnect, create_tc_arg_parser
-from threatconnect.Resources.Adversaries import (Adversaries, AdversaryFilterObject)
-from threatconnect.Resources.Emails import (Emails, EmailFilterObject)
-from threatconnect.Resources.Groups import (Groups, GroupFilterObject)
-from threatconnect.Resources.Incidents import (Incidents, IncidentFilterObject)
-from threatconnect.Resources.Indicators import IndicatorFilterObject
-from threatconnect.Resources import Indicators
-from threatconnect.Resources.Owners import (Owners, OwnerFilterObject)
-from threatconnect.Resources.Signatures import (Signatures, SignatureFilterObject)
-from threatconnect.Resources.Threats import (Threats, ThreatFilterObject)
-from threatconnect.Resources.Victims import (Victims, VictimFilterObject)
-from threatconnect.Config.ResourceType import *
-from threatconnect.Config.FilterOperator import *
+from ThreatConnect import ThreatConnect, create_tc_arg_parser
+from Resources.Adversaries import (Adversaries, AdversaryFilterObject)
+from Resources.Emails import (Emails, EmailFilterObject)
+from Resources.Groups import (Groups, GroupFilterObject)
+from Resources.Incidents import (Incidents, IncidentFilterObject)
+from Resources.Indicators import IndicatorFilterObject
+from Resources import Indicators
+from Resources.Owners import (Owners, OwnerFilterObject)
+from Resources.Signatures import (Signatures, SignatureFilterObject)
+from Resources.Threats import (Threats, ThreatFilterObject)
+from Resources.Victims import (Victims, VictimFilterObject)
+from Config.ResourceType import *
+from Config.FilterOperator import *


### PR DESCRIPTION
Lots of circular imports.

No visible impact on Linux Python 3.2 - 3.5.1

Changed setup.py to automatically find packages and fixed version number.