### PR TITLE
Remove enum34 dependency for python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
     # test_suite = '',
     url='https://github.com/ThreatConnect-Inc/threatconnect-python',
     license='GPLv3',
-    install_requires=['requests', 'enum34', 'python-dateutil', 'psutil'],
+    install_requires=['requests', 'python-dateutil', 'psutil'],
+    extras_require={
+        ':python_version=="2.7"': ['enum34']
+    },
     # test_suite = '',
     use_2to3=True,
     # convert_2to3_doctests = [''],


### PR DESCRIPTION
enum34 is a backport for python 2 of enum. This patch moves the dependency to an extra that is only required for python 2.7.