### PR TITLE
Remove dependency on psutil - code that uses it is commented out.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/ThreatConnect-Inc/threatconnect-python',
     download_url='https://github.com/ThreatConnect-Inc/threatconnect-python/tarball/2.3',
     license='GPLv3',
-    install_requires=['requests', 'python-dateutil', 'psutil'],
+    install_requires=['requests', 'python-dateutil'],
     extras_require={
         ':python_version=="2.7"': ['enum34']
     },


### PR DESCRIPTION
psutil is only used in commented out code. The comment mentions that it is for testing. This dependency can be removed for the production release of the SDK to slim down everyone's installs. If we need it for testing, a local change can add it back easily.