### PR TITLE
update config to make sample scripts runnable

### DIFF
--- a/examples/commit/tc.conf-template
+++ b/examples/commit/tc.conf-template
@@ -21,3 +21,5 @@ api_secret_key = <API SECRET KEY>
 # api base url - ENTER API BASE URL (e.g. https://api.threatconnect.com OR https://my.threatconnect.com/api)
 #
 api_base_url = https://api.threatconnect.com
+
+api_result_limit = 500

--- a/examples/retrieve/tc.conf-template
+++ b/examples/retrieve/tc.conf-template
@@ -21,3 +21,5 @@ api_secret_key = <API SECRET KEY>
 # api base url - ENTER API BASE URL (e.g. https://api.threatconnect.com OR https://my.threatconnect.com/api)
 #
 api_base_url = https://api.threatconnect.com
+
+api_result_limit = 500


### PR DESCRIPTION
fixes an issue where running scripts under `/examples` would throw a cryptic error

i.e. [running this script](https://github.com/ThreatConnect-Inc/threatconnect-python/blob/master/examples/retrieve/indicators_retrieve.py#L28) using the [provided config file](https://github.com/ThreatConnect-Inc/threatconnect-python/blob/77ecbc5f7a48b591a45654d176af8fecb3c06da8/examples/retrieve/tc.conf-template)
