### PR TITLE
Fixed RequestObject to be RFC compliant with Content-Length header

### DIFF
--- a/threatconnect/RequestObject.py
+++ b/threatconnect/RequestObject.py
@@ -68,7 +68,7 @@ class RequestObject(object):
     def set_body(self, data):
         """ set the POST/PUT body content """
         self._body = data
-        self._headers['Content-Length'] = len(self._body)
+        self._headers['Content-Length'] = str(len(self._body))
 
     def set_content_type(self, data):
         """ allow manual setting of content type """


### PR DESCRIPTION
This is to fix Issue 20.  RFC states that headers are char strings, upstream requests library no longer handles this for us.  This should resolve that issue.