### PR TITLE
Fix NE operator for Tags

### DIFF
--- a/threatconnect/Resource.py
+++ b/threatconnect/Resource.py
@@ -292,10 +292,19 @@ class Resource(object):
             # tags (nested object)
             #
             if hasattr(data_obj, 'tags'):
-                if len(data_obj.tags) > 0:
-                    for tag_obj in data_obj.tags:
-                        self._tag_idx.setdefault(
-                            tag_obj.name, []).append(data_obj)
+                if data_obj.resource_type==ResourceType.FILES:
+                    advancedcreator=IndicatorObjectParser.IndicatorObjectParser(self.tc)
+                    advanced_obj=advancedcreator.construct_typed_advanced_indicator(self,data_obj)
+                    advanced_obj.load_tags()
+                    if len(advanced_obj.tags) > 0:
+                        for tag_obj in advanced_obj.tags:
+                            self._tag_idx.setdefault(
+                                tag_obj.name, []).append(data_obj) #tag with original's address.
+                else:
+                    if len(data_obj.tags) > 0:
+                        for tag_obj in data_obj.tags:
+                            self._tag_idx.setdefault(
+                                tag_obj.name, []).append(data_obj)
 
         return resource_object_id
 

--- a/threatconnect/Resource.py
+++ b/threatconnect/Resource.py
@@ -8,6 +8,7 @@ from BatchJobObject import BatchJobObject
 from GroupObject import GroupObject
 from TaskObject import TaskObject
 from VictimObject import VictimObject
+import IndicatorObjectParser
 
 from Config.ResourceType import ResourceType
 from Config.FilterOperator import FilterOperator
@@ -447,6 +448,11 @@ class Resource(object):
                 for data_obj in self._tag_idx[data]:
                     data_obj.add_matched_filter(description)
                     yield data_obj
+        if operator == FilterOperator.NE:
+            not_tagged_with = list(set(self._master_objects).difference(self._tag_idx[data]))
+            for data_obj in not_tagged_with:
+                data_obj.add_matched_filter(description)
+                yield data_obj
         else:
             for key, data_obj_list in self._tag_idx.items():
                 if operator.value(key, data):


### PR DESCRIPTION
NE operator not working for tags.  If the indicator has no tags at all it was not included in the returned indicators.
also if an indicator had more than one tag it was always included using NE