### PR TITLE
fix for requests version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ if not version:
     raise RuntimeError('Cannot find version information')
 
 install_requires = [
-    'python-dateutil==2.6.0',
-    'requests==2.17.3',
+    'python-dateutil>=2.6.0',
+    'requests>=2.17.3',
 ]
 if sys.version_info < (3, ):
     install_requires.append('enum34')


### PR DESCRIPTION
Remove strict version restriction on dependencies. This inhibits interoperability with other components in the same python environment.