### PR TITLE
Adding missing import for pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ if not version:
 install_requires = [
     'python-dateutil==2.6.0',
     'requests==2.17.3',
+    'pytz',
 ]
 if sys.version_info < (3, ):
     install_requires.append('enum34')

--- a/threatconnect/IndicatorFilterMethods.py
+++ b/threatconnect/IndicatorFilterMethods.py
@@ -1,9 +1,9 @@
 """ standard """
 import time
-import pytz
 
 """ third-party """
 import dateutil.parser
+import pytz
 
 """ custom """
 from Config.FilterOperator import FilterOperator


### PR DESCRIPTION
I'm getting the following error when trying to run use this SDK:

`ModuleNotFoundError: No module named 'pytz'`.

From what I can tell, `pytz` isn't a built-in package, so I've added it to the required packages in setup.py.